### PR TITLE
Update status message for OneKitchen and Restaurant Driver Messages

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020 helpberkeley.org
+Copyright (c) 2020-2024 helpberkeley.org
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/helpberkeley/memberdata/Constants.java
+++ b/src/main/java/org/helpberkeley/memberdata/Constants.java
@@ -68,6 +68,7 @@ public class Constants {
     public static final int QUERY_GET_LAST_REPLY_FROM_REQUEST_TOPICS_V20 = 58;
     public static final int QUERY_GET_LAST_REPLY_FROM_REQUEST_TOPICS_V21 = 64;
     public static final int QUERY_GET_LAST_REPLY_FROM_REQUEST_TOPICS_V22 = 77;
+    public static final int QUERY_GET_LAST_REPLY_FROM_REQUEST_TOPICS_V23 = 81;
     public static final int QUERY_GET_CURRENT_VALIDATED_ONE_KITCHEN_RESTAURANT_TEMPLATE = 51;
     public static final int QUERY_GET_LAST_TEST_REQUEST = 52;
     public static final int QUERY_GET_ONE_KITCHEN_DRIVERS_POST_FORMAT_V300 = 53;
@@ -95,8 +96,10 @@ public class Constants {
     public static final int QUERY_GET_GROUP_INSTRUCTIONS_FORMAT = QUERY_GET_GROUP_INSTRUCTIONS_FORMAT_V22;
     public static final int QUERY_GET_BACKUP_DRIVER_FORMAT = QUERY_GET_BACKUP_DRIVER_FORMAT_V12;
     public static final int QUERY_EMAIL_CONFIRMATIONS = QUERY_EMAIL_CONFIRMATIONS_V1;
-    public static final int QUERY_GET_REQUESTS_LAST_REPLIES = QUERY_GET_LAST_REPLY_FROM_REQUEST_TOPICS_V22;
+    public static final int QUERY_GET_REQUESTS_LAST_REPLIES = QUERY_GET_LAST_REPLY_FROM_REQUEST_TOPICS_V23;
 
+    public static final Topic TOPIC_STONE_TEST_TOPIC = new Topic("Stone test topic", 422);
+    static final Topic TOPIC_DRIVERS_POST_STAGING = new Topic("Get Driver Messages", 2123);
     public static final Topic TOPIC_REQUEST_DRIVER_MESSAGES = new Topic("Request Driver Messages", 2504);
     public static final Topic TOPIC_REQUEST_DRIVER_ROUTES = new Topic("Request Driver Routes", 2844);
     public static final Topic TOPIC_POST_RESTAURANT_TEMPLATE = new Topic("Post restaurant template", 1860);

--- a/src/main/java/org/helpberkeley/memberdata/ControlBlock.java
+++ b/src/main/java/org/helpberkeley/memberdata/ControlBlock.java
@@ -256,7 +256,7 @@ public abstract class ControlBlock {
     }
 
     public OpsManager getFirstOpsManager() {
-        if (opsManagers.size() == 0) {
+        if (opsManagers.isEmpty()) {
             throw new MemberDataException("No OpsManager found");
         }
 

--- a/src/main/java/org/helpberkeley/memberdata/Options.java
+++ b/src/main/java/org/helpberkeley/memberdata/Options.java
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020-2021 helpberkeley.org
+// Copyright (c) 2020-2024 helpberkeley.org
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -52,7 +52,6 @@ public class Options {
     static final String COMMAND_CUSTOMER_CARE_POST = "customer-care";
     static final String COMMAND_FRREG = "frreg";
     static final String COMMAND_WORK_REQUESTS = "work-requests";
-    static final String COMMAND_TEST_REQUEST = "test-request";
 
     static final String USAGE_ERROR = "Usage error for command ";
     static final String UNKNOWN_COMMAND = USAGE_ERROR + ": unknown command: ";
@@ -89,8 +88,7 @@ public class Options {
                     + "    | " + COMMAND_CUSTOMER_CARE_POST + " all-members-file\n"
                     + "    | " + COMMAND_FRREG + " all-members-file\n"
                     + "    | " + COMMAND_RESTAURANT_TEMPLATE + "\n"
-                    + "    | " + COMMAND_ONE_KITCHEN_RESTAURANT_TEMPLATE + "\n"
-                    + "    | " + COMMAND_TEST_REQUEST + " all-members-file\n";
+                    + "    | " + COMMAND_ONE_KITCHEN_RESTAURANT_TEMPLATE + "\n";
 
     private final String[] args;
     private String command;
@@ -142,7 +140,6 @@ public class Options {
             case COMMAND_CUSTOMER_CARE_POST:
             case COMMAND_FRREG:
             case COMMAND_DRIVERS:
-            case COMMAND_TEST_REQUEST:
                 setCommand(arg);
                 if (index == args.length) {
                     dieMessage(USAGE_ERROR + arg + COMMAND_REQUIRES_FILE_NAME);

--- a/src/main/java/org/helpberkeley/memberdata/OrderHistory.java
+++ b/src/main/java/org/helpberkeley/memberdata/OrderHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020. helpberkeley.org
+ * Copyright (c) 2020-2024. helpberkeley.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -89,7 +89,7 @@ public class OrderHistory {
         SortedMap<String, OrderHistoryData> newPosts = dataPosts.getNewPosts();
 
         // Nothing to merge
-        if (newPosts.size() == 0) {
+        if (newPosts.isEmpty()) {
             return;
         }
 

--- a/src/main/java/org/helpberkeley/memberdata/Topic.java
+++ b/src/main/java/org/helpberkeley/memberdata/Topic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020. helpberkeley.org
+ * Copyright (c) 2020-2024. helpberkeley.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,9 +24,9 @@ package org.helpberkeley.memberdata;
 
 public class Topic {
     private final String name;
-    private final int id;
+    private final long id;
 
-    public Topic(final String name, final int id) {
+    public Topic(final String name, final long id) {
         this.name = name;
         this.id = id;
     }
@@ -35,7 +35,12 @@ public class Topic {
         return name;
     }
 
-    public int getId() {
+    public long getId() {
         return id;
+    }
+
+    @Override
+    public String toString() {
+        return id + ": " + name;
     }
 }

--- a/src/main/java/org/helpberkeley/memberdata/v200/DriverPostFormatV200.java
+++ b/src/main/java/org/helpberkeley/memberdata/v200/DriverPostFormatV200.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021. helpberkeley.org
+ * Copyright (c) 2020-2024. helpberkeley.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -92,7 +92,7 @@ public class DriverPostFormatV200 extends DriverPostFormat {
         if (! controlBlock.restaurantsAuditDisabled()) {
             // Restaurants with no drivers
             for (Restaurant restaurant : restaurants.values()) {
-                if (restaurant.getDrivers().size() == 0) {
+                if (restaurant.getDrivers().isEmpty()) {
                     summary.append("No drivers going to ").append(restaurant.getName()).append("\n");
                 }
             }

--- a/src/main/java/org/helpberkeley/memberdata/v200/DriverV200.java
+++ b/src/main/java/org/helpberkeley/memberdata/v200/DriverV200.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021. helpberkeley.org
+ * Copyright (c) 2021-2024. helpberkeley.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -65,7 +65,7 @@ public class DriverV200 extends Driver {
 
     private void setStartTime() {
 
-        if (pickups.size() == 0) {
+        if (pickups.isEmpty()) {
             throw new MemberDataException("Driver " + getUserName() + " has no pickups");
         }
 

--- a/src/main/java/org/helpberkeley/memberdata/v200/RestaurantBeanV200.java
+++ b/src/main/java/org/helpberkeley/memberdata/v200/RestaurantBeanV200.java
@@ -41,7 +41,7 @@ public class RestaurantBeanV200 implements RestaurantBean {
     private String altPhone;
 
     @CsvBindByName(column = Constants.WORKFLOW_PHONE_COLUMN)
-    private String phone;;
+    private String phone;
 
     @CsvBindByName(column = Constants.WORKFLOW_CONSUMER_COLUMN)
     private String consumer;

--- a/src/main/java/org/helpberkeley/memberdata/v300/DriverPostFormatV300.java
+++ b/src/main/java/org/helpberkeley/memberdata/v300/DriverPostFormatV300.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022. helpberkeley.org
+ * Copyright (c) 2020-2024. helpberkeley.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -180,7 +180,7 @@ public class DriverPostFormatV300 extends DriverPostFormat {
             for (Restaurant restaurant : restaurants.values()) {
                 if ((restaurant.getName().equals(controlBlock.getMealSource())
                         || restaurant.getName().equals(controlBlock.getGrocerySource()))
-                    && (restaurant.getDrivers().size() == 0)) {
+                    && (restaurant.getDrivers().isEmpty())) {
                         summary.append("No drivers going to ").append(restaurant.getName()).append("\n");
                 }
             }

--- a/src/test/java/org/helpberkeley/memberdata/HttpClientSimulator.java
+++ b/src/test/java/org/helpberkeley/memberdata/HttpClientSimulator.java
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020-2021 helpberkeley.org
+// Copyright (c) 2020-2024 helpberkeley.org
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -238,6 +238,7 @@ public class HttpClientSimulator extends HttpClient {
             case Constants.QUERY_GET_LAST_REPLY_FROM_REQUEST_TOPICS_V20:
             case Constants.QUERY_GET_LAST_REPLY_FROM_REQUEST_TOPICS_V21:
             case Constants.QUERY_GET_LAST_REPLY_FROM_REQUEST_TOPICS_V22:
+            case Constants.QUERY_GET_LAST_REPLY_FROM_REQUEST_TOPICS_V23:
                 dataFile = "last-replies-no-requests.json";
                 break;
             case Constants.QUERY_GET_LAST_ONE_KITCHEN_RESTAURANT_TEMPLATE_REPLY:

--- a/src/test/java/org/helpberkeley/memberdata/MainTest.java
+++ b/src/test/java/org/helpberkeley/memberdata/MainTest.java
@@ -158,9 +158,9 @@ public class MainTest extends TestBase {
         Post statusPost = WorkRequestHandler.getLastStatusPost();
         assertThat(statusPost).isNotNull();
         assertThat(statusPost.raw).contains("Status: Succeeded");
-        assertThat(statusPost.raw).contains(
-                "Messages Posted to [" + Constants.TOPIC_DRIVERS_POST_STAGING.getName() + "]");
-        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_REQUEST_DRIVER_MESSAGES.getId());
+        assertThat(statusPost.raw).contains(MessageFormat.format(Main.MESSAGES_POST_TO,
+                Constants.TOPIC_DRIVERS_POST_STAGING.getName(),
+                String.valueOf(Constants.TOPIC_DRIVERS_POST_STAGING.getId())));
     }
     @Test
     public void driverMessagesTestTopicTest() throws IOException, CsvException {
@@ -176,8 +176,9 @@ public class MainTest extends TestBase {
         Post statusPost = WorkRequestHandler.getLastStatusPost();
         assertThat(statusPost).isNotNull();
         assertThat(statusPost.raw).contains("Status: Succeeded");
-        assertThat(statusPost.raw).contains(
-                "Messages Posted to [" + Constants.TOPIC_STONE_TEST_TOPIC.getName() + "]");
+        assertThat(statusPost.raw).contains(MessageFormat.format(Main.MESSAGES_POST_TO,
+                Constants.TOPIC_STONE_TEST_TOPIC.getName(),
+                String.valueOf(Constants.TOPIC_STONE_TEST_TOPIC.getId())));
         assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_REQUEST_DRIVER_MESSAGES.getId());
     }
 
@@ -242,10 +243,9 @@ public class MainTest extends TestBase {
         Post statusPost = WorkRequestHandler.getLastStatusPost();
         assertThat(statusPost).isNotNull();
         assertThat(statusPost.raw).contains("Status: Succeeded");
-        assertThat(statusPost.raw).contains(
-                "Messages Posted to [" + Constants.TOPIC_DRIVERS_POST_STAGING.getName() + "]");
-        assertThat(statusPost.raw).contains(
-                "/" + Constants.TOPIC_DRIVERS_POST_STAGING.getId());
+        assertThat(statusPost.raw).contains(MessageFormat.format(Main.MESSAGES_POST_TO,
+                Constants.TOPIC_DRIVERS_POST_STAGING.getName(),
+                String.valueOf(Constants.TOPIC_DRIVERS_POST_STAGING.getId())));
     }
 
     @Test
@@ -262,10 +262,10 @@ public class MainTest extends TestBase {
         Post statusPost = WorkRequestHandler.getLastStatusPost();
         assertThat(statusPost).isNotNull();
         assertThat(statusPost.raw).contains("Status: Succeeded");
-        assertThat(statusPost.raw).contains(
-                "Messages Posted to [" + Constants.TOPIC_STONE_TEST_TOPIC.getName() + "]");
-        assertThat(statusPost.raw).contains(
-                "/" + Constants.TOPIC_STONE_TEST_TOPIC.getId());
+        assertThat(statusPost.raw).contains(MessageFormat.format(Main.MESSAGES_POST_TO,
+                Constants.TOPIC_STONE_TEST_TOPIC.getName(),
+                String.valueOf(Constants.TOPIC_STONE_TEST_TOPIC.getId())));
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_REQUEST_ONE_KITCHEN_DRIVER_MESSAGES.getId());
     }
 
     @Test
@@ -327,10 +327,10 @@ public class MainTest extends TestBase {
         assertThat(statusPost).isNotNull();
         assertThat(statusPost.raw).contains("Status: Succeeded");
         assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_REQUEST_ONE_KITCHEN_DRIVER_MESSAGES.getId());
-        assertThat(statusPost.raw).contains(
-                "Messages Posted to [" + Constants.TOPIC_DRIVERS_POST_STAGING.getName() + "]");
-        assertThat(statusPost.raw).contains(
-                "/" + Constants.TOPIC_DRIVERS_POST_STAGING.getId());
+        assertThat(statusPost.raw).contains(MessageFormat.format(Main.MESSAGES_POST_TO,
+                Constants.TOPIC_DRIVERS_POST_STAGING.getName(),
+                String.valueOf(Constants.TOPIC_DRIVERS_POST_STAGING.getId())));
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_REQUEST_ONE_KITCHEN_DRIVER_MESSAGES.getId());
     }
 
     private void oneKitchenDriverMessagesWrongSheetTest(String filename, String version) throws IOException, CsvException {

--- a/src/test/java/org/helpberkeley/memberdata/MainTest.java
+++ b/src/test/java/org/helpberkeley/memberdata/MainTest.java
@@ -48,11 +48,14 @@ public class MainTest extends TestBase {
         // Fetches files that will be used by the tests.
         String[] args = { Options.COMMAND_FETCH };
         Main.main(args);
+
+        WorkRequestHandler.clearLastStatusPost();
     }
 
     @AfterClass
     public static void cleanup() throws IOException {
         cleanupGeneratedFiles();
+        WorkRequestHandler.clearLastStatusPost();
     }
 
     @Test
@@ -152,8 +155,30 @@ public class MainTest extends TestBase {
         String usersFile = findFile(Constants.MEMBERDATA_RAW_FILE, "csv");
         String[] args = { Options.COMMAND_DRIVER_MESSAGES, usersFile };
         Main.main(args);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Succeeded");
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Succeeded");
+        assertThat(statusPost.raw).contains(
+                "Messages Posted to [" + Constants.TOPIC_DRIVERS_POST_STAGING.getName() + "]");
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_REQUEST_DRIVER_MESSAGES.getId());
+    }
+    @Test
+    public void driverMessagesTestTopicTest() throws IOException, CsvException {
+        String request = readResourceFile(REQUEST_TEMPLATE_EXTRA)
+                .replace("REPLACE_DATE", yesterday())
+                .replace("REPLACE_EXTRA", "Test topic")
+                .replaceAll("REPLACE_FILENAME", "routed-deliveries-v200.csv");
+        HttpClientSimulator.setQueryResponseData(
+                Constants.QUERY_GET_LAST_REQUEST_DRIVER_MESSAGES_REPLY, request);
+        String usersFile = findFile(Constants.MEMBERDATA_RAW_FILE, "csv");
+        String[] args = { Options.COMMAND_DRIVER_MESSAGES, usersFile };
+        Main.main(args);
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Succeeded");
+        assertThat(statusPost.raw).contains(
+                "Messages Posted to [" + Constants.TOPIC_STONE_TEST_TOPIC.getName() + "]");
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_REQUEST_DRIVER_MESSAGES.getId());
     }
 
     @Test
@@ -179,12 +204,14 @@ public class MainTest extends TestBase {
         String usersFile = findFile(Constants.MEMBERDATA_RAW_FILE, "csv");
         String[] args = { Options.COMMAND_DRIVER_MESSAGES, usersFile };
         Main.main(args);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Fail");
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains(MessageFormat.format(
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Fail");
+        assertThat(statusPost.raw).contains(MessageFormat.format(
                 Main.WRONG_REQUEST_TOPIC, version,
                 Main.buildTopicURL(Constants.TOPIC_REQUEST_DRIVER_MESSAGES),
                 Main.buildTopicURL(Constants.TOPIC_REQUEST_ONE_KITCHEN_DRIVER_MESSAGES)));
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_REQUEST_DRIVER_MESSAGES.getId());
     }
 
     @Test
@@ -197,12 +224,14 @@ public class MainTest extends TestBase {
         String usersFile = findFile(Constants.MEMBERDATA_RAW_FILE, "csv");
         String[] args = { Options.COMMAND_DRIVER_MESSAGES, usersFile };
         Main.main(args);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Fail");
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains(MessageFormat.format(
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Fail");
+        assertThat(statusPost.raw).contains(MessageFormat.format(
                 Main.UNSUPPORTED_CONTROL_BLOCK_VERSION, "0",
                 Main.buildTopicURL(Constants.TOPIC_REQUEST_DRIVER_MESSAGES),
                 Constants.CONTROL_BLOCK_VERSION_200));
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_REQUEST_DRIVER_MESSAGES.getId());
     }
 
     @Test
@@ -210,12 +239,39 @@ public class MainTest extends TestBase {
         String usersFile = findFile(Constants.MEMBERDATA_RAW_FILE, "csv");
         String[] args = { Options.COMMAND_ONE_KITCHEN_DRIVER_MESSAGES, usersFile };
         Main.main(args);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Succeeded");
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Succeeded");
+        assertThat(statusPost.raw).contains(
+                "Messages Posted to [" + Constants.TOPIC_DRIVERS_POST_STAGING.getName() + "]");
+        assertThat(statusPost.raw).contains(
+                "/" + Constants.TOPIC_DRIVERS_POST_STAGING.getId());
+    }
+
+    @Test
+    public void oneKitchenDriverMessagesTestTopicTest() throws IOException, CsvException {
+        String request = readResourceFile(REQUEST_TEMPLATE_EXTRA)
+                .replace("REPLACE_DATE", yesterday())
+                .replace("REPLACE_EXTRA", "Test topic")
+                .replaceAll("REPLACE_FILENAME", "routed-deliveries-v300.csv");
+        HttpClientSimulator.setQueryResponseData(
+                Constants.QUERY_GET_LAST_REQUEST_ONE_KITCHEN_DRIVER_MESSAGES_REPLY, request);
+        String usersFile = findFile(Constants.MEMBERDATA_RAW_FILE, "csv");
+        String[] args = { Options.COMMAND_ONE_KITCHEN_DRIVER_MESSAGES, usersFile };
+        Main.main(args);
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Succeeded");
+        assertThat(statusPost.raw).contains(
+                "Messages Posted to [" + Constants.TOPIC_STONE_TEST_TOPIC.getName() + "]");
+        assertThat(statusPost.raw).contains(
+                "/" + Constants.TOPIC_STONE_TEST_TOPIC.getId());
     }
 
     @Test
     public void oneKitchenDriverMessagesMissingFormulaTest() throws IOException, CsvException {
+        // FIX THIS, DS: update this test to send errors in the user request upload file
+        //               see issue: Invalid formula not being detected #14
         String request = readResourceFile(REQUEST_TEMPLATE)
                 .replace("REPLACE_DATE", yesterday())
                 .replaceAll("REPLACE_FILENAME", "restaurant-template-v302-missing-formula.csv");
@@ -224,12 +280,16 @@ public class MainTest extends TestBase {
         String usersFile = findFile(Constants.MEMBERDATA_RAW_FILE, "csv");
         String[] args = { Options.COMMAND_ONE_KITCHEN_DRIVER_MESSAGES, usersFile };
         Main.main(args);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Succeeded");
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Succeeded");
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_REQUEST_ONE_KITCHEN_DRIVER_MESSAGES.getId());
     }
 
     @Test
     public void oneKitchenDriverMessagesMissingFormulaDirectiveTest() throws IOException, CsvException {
+        // FIX THIS, DS: update this test to send errors in the user request upload file
+        //               see issue: Invalid formula not being detected #14
         String request = readResourceFile(REQUEST_TEMPLATE)
                 .replace("REPLACE_DATE", yesterday())
                 .replaceAll("REPLACE_FILENAME", "restaurant-template-v302-missing-formula-directive.csv");
@@ -238,8 +298,10 @@ public class MainTest extends TestBase {
         String usersFile = findFile(Constants.MEMBERDATA_RAW_FILE, "csv");
         String[] args = { Options.COMMAND_ONE_KITCHEN_DRIVER_MESSAGES, usersFile };
         Main.main(args);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
         assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Succeeded");
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_REQUEST_ONE_KITCHEN_DRIVER_MESSAGES.getId());
     }
 
     @Test
@@ -261,8 +323,14 @@ public class MainTest extends TestBase {
         String usersFile = findFile(Constants.MEMBERDATA_RAW_FILE, "csv");
         String[] args = { Options.COMMAND_ONE_KITCHEN_DRIVER_MESSAGES, usersFile };
         Main.main(args);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Succeeded");
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Succeeded");
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_REQUEST_ONE_KITCHEN_DRIVER_MESSAGES.getId());
+        assertThat(statusPost.raw).contains(
+                "Messages Posted to [" + Constants.TOPIC_DRIVERS_POST_STAGING.getName() + "]");
+        assertThat(statusPost.raw).contains(
+                "/" + Constants.TOPIC_DRIVERS_POST_STAGING.getId());
     }
 
     private void oneKitchenDriverMessagesWrongSheetTest(String filename, String version) throws IOException, CsvException {
@@ -274,12 +342,14 @@ public class MainTest extends TestBase {
         String usersFile = findFile(Constants.MEMBERDATA_RAW_FILE, "csv");
         String[] args = { Options.COMMAND_ONE_KITCHEN_DRIVER_MESSAGES, usersFile };
         Main.main(args);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Fail");
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains(MessageFormat.format(
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Fail");
+        assertThat(statusPost.raw).contains(MessageFormat.format(
                 Main.WRONG_REQUEST_TOPIC, version,
                 Main.buildTopicURL(Constants.TOPIC_REQUEST_ONE_KITCHEN_DRIVER_MESSAGES),
-            Main.buildTopicURL(Constants.TOPIC_REQUEST_DRIVER_MESSAGES)));
+                Main.buildTopicURL(Constants.TOPIC_REQUEST_DRIVER_MESSAGES)));
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_REQUEST_ONE_KITCHEN_DRIVER_MESSAGES.getId());
     }
 
     @Test
@@ -292,12 +362,14 @@ public class MainTest extends TestBase {
         String usersFile = findFile(Constants.MEMBERDATA_RAW_FILE, "csv");
         String[] args = { Options.COMMAND_ONE_KITCHEN_DRIVER_MESSAGES, usersFile };
         Main.main(args);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Fail");
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains(MessageFormat.format(
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Failed");
+        assertThat(statusPost.raw).contains(MessageFormat.format(
                 Main.UNSUPPORTED_CONTROL_BLOCK_VERSION, "0",
                 Main.buildTopicURL(Constants.TOPIC_REQUEST_ONE_KITCHEN_DRIVER_MESSAGES),
                 Constants.CONTROL_BLOCK_VERSION_300));
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_REQUEST_ONE_KITCHEN_DRIVER_MESSAGES.getId());
     }
 
     @Test
@@ -307,8 +379,9 @@ public class MainTest extends TestBase {
                 Constants.QUERY_GET_LAST_REQUEST_DRIVER_MESSAGES_REPLY, "last-routed-workflow-status.json");
         String[] args = { Options.COMMAND_DRIVER_MESSAGES, usersFile };
         Main.main(args);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Succeeded");
+        // There should be nothing to do. All topics have
+        // status messages as their last reply.
+        assertThat(WorkRequestHandler.getLastStatusPost()).isNull();
     }
 
     @Test
@@ -345,6 +418,7 @@ public class MainTest extends TestBase {
         Post statusPost = WorkRequestHandler.getLastStatusPost();
         assertThat(statusPost).isNotNull();
         assertThat(statusPost.raw).contains("Status: Succeeded");
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_POST_COMPLETED_DAILY_ORDERS.getId());
     }
 
     @Test
@@ -489,10 +563,10 @@ public class MainTest extends TestBase {
         String[] args = { Options.COMMAND_COMPLETED_ONEKITCHEN_ORDERS, usersFile };
         WorkRequestHandler.clearLastStatusPost();
         Main.main(args);
-
         Post statusPost = WorkRequestHandler.getLastStatusPost();
         assertThat(statusPost).isNotNull();
         assertThat(statusPost.raw).contains("Status: Succeeded");
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_POST_COMPLETED_ONEKITCHEN_ORDERS.getId());
     }
 
     @Test
@@ -528,10 +602,11 @@ public class MainTest extends TestBase {
         String[] args = { Options.COMMAND_COMPLETED_ONEKITCHEN_ORDERS, usersFile };
         WorkRequestHandler.clearLastStatusPost();
         Main.main(args);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        String statusMessage = WorkRequestHandler.getLastStatusPost().raw;
-        assertThat(statusMessage).contains("Status: Failed");
-        assertThat(statusMessage).contains(MessageFormat.format(Main.DATE_IS_IN_THE_FUTURE, tomorrowStr));
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Failed");
+        assertThat(statusPost.raw).contains(MessageFormat.format(Main.DATE_IS_IN_THE_FUTURE, tomorrowStr));
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_POST_COMPLETED_ONEKITCHEN_ORDERS.getId());
     }
 
     @Test
@@ -569,9 +644,10 @@ public class MainTest extends TestBase {
         String[] args = { Options.COMMAND_COMPLETED_ONEKITCHEN_ORDERS, usersFile };
         WorkRequestHandler.clearLastStatusPost();
         Main.main(args);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        String statusMessage = WorkRequestHandler.getLastStatusPost().raw;
-        assertThat(statusMessage).contains("Status: Succeeded");
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Succeeded");
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_POST_COMPLETED_ONEKITCHEN_ORDERS.getId());
     }
 
     @Test
@@ -603,22 +679,6 @@ public class MainTest extends TestBase {
     public void oneKitchenDriverHistoryTest() throws IOException, CsvException {
         String[] args = { Options.COMMAND_ONEKITCHEN_DRIVER_HISTORY };
         Main.main(args);
-    }
-
-    @Test
-    public void restaurantTemplateTest() throws IOException, CsvException {
-        String[] args = { Options.COMMAND_RESTAURANT_TEMPLATE };
-        Main.main(args);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Succeeded");
-    }
-
-    @Test
-    public void oneKitchenRestaurantTemplateTest() throws IOException, CsvException {
-        String[] args = { Options.COMMAND_ONE_KITCHEN_RESTAURANT_TEMPLATE };
-        Main.main(args);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Succeeded");
     }
 
     @Test
@@ -663,14 +723,15 @@ public class MainTest extends TestBase {
     }
 
     @Test
-    public void workRequestsBadRequestTest() throws IOException, CsvException {
+    public void workRequestsBadPreviousRequestTest() throws IOException, CsvException {
         HttpClientSimulator.setQueryResponseFile(
                 Constants.QUERY_GET_REQUESTS_LAST_REPLIES, "last-replies-bad-request.json");
         String usersFile = findFile(Constants.MEMBERDATA_RAW_FILE, "csv");
         String[] args = { Options.COMMAND_WORK_REQUESTS, usersFile };
         Main.main(args);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Fail");
+        // There should be nothing to do. All topics have
+        // status messages as their last reply.
+        assertThat(WorkRequestHandler.getLastStatusPost()).isNull();
     }
 
     @Test
@@ -692,13 +753,14 @@ public class MainTest extends TestBase {
         String usersFile = findFile(Constants.MEMBERDATA_RAW_FILE, "csv");
         String[] args = { Options.COMMAND_COMPLETED_ONEKITCHEN_ORDERS, usersFile };
         Main.main(args);
-        System.out.println(WorkRequestHandler.getLastStatusPost().raw);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Fail");
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains(MessageFormat.format(
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Fail");
+        assertThat(statusPost.raw).contains(MessageFormat.format(
                 Main.WRONG_REQUEST_TOPIC, version,
                 Main.buildTopicURL(Constants.TOPIC_POST_COMPLETED_ONEKITCHEN_ORDERS),
                 Main.buildTopicURL(Constants.TOPIC_POST_COMPLETED_DAILY_ORDERS)));
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_POST_COMPLETED_ONEKITCHEN_ORDERS.getId());
     }
 
     @Test
@@ -725,9 +787,10 @@ public class MainTest extends TestBase {
         String usersFile = findFile(Constants.MEMBERDATA_RAW_FILE, "csv");
         String[] args = { Options.COMMAND_COMPLETED_ONEKITCHEN_ORDERS, usersFile };
         Main.main(args);
-        System.out.println(WorkRequestHandler.getLastStatusPost().raw);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Succeeded");
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Succeeded");
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_POST_COMPLETED_ONEKITCHEN_ORDERS.getId());
     }
 
     @Test
@@ -754,13 +817,14 @@ public class MainTest extends TestBase {
         String usersFile = findFile(Constants.MEMBERDATA_RAW_FILE, "csv");
         String[] args = { Options.COMMAND_COMPLETED_DAILY_ORDERS, usersFile };
         Main.main(args);
-        System.out.println(WorkRequestHandler.getLastStatusPost().raw);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Fail");
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains(MessageFormat.format(
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Fail");
+        assertThat(statusPost.raw).contains(MessageFormat.format(
                 Main.WRONG_REQUEST_TOPIC, version,
                 Main.buildTopicURL(Constants.TOPIC_POST_COMPLETED_DAILY_ORDERS),
                 Main.buildTopicURL(Constants.TOPIC_POST_COMPLETED_ONEKITCHEN_ORDERS)));
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_POST_COMPLETED_DAILY_ORDERS.getId());
     }
 
     @Test
@@ -782,9 +846,10 @@ public class MainTest extends TestBase {
         String usersFile = findFile(Constants.MEMBERDATA_RAW_FILE, "csv");
         String[] args = { Options.COMMAND_COMPLETED_DAILY_ORDERS, usersFile };
         Main.main(args);
-        System.out.println(WorkRequestHandler.getLastStatusPost().raw);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Succeeded");
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Succeeded");
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_POST_COMPLETED_DAILY_ORDERS.getId());
     }
 
     @Test
@@ -805,13 +870,14 @@ public class MainTest extends TestBase {
                 Constants.QUERY_GET_LAST_ONE_KITCHEN_RESTAURANT_TEMPLATE_REPLY, request);
         String[] args = { Options.COMMAND_ONE_KITCHEN_RESTAURANT_TEMPLATE };
         Main.main(args);
-        System.out.println(WorkRequestHandler.getLastStatusPost().raw);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Fail");
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains(MessageFormat.format(
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Fail");
+        assertThat(statusPost.raw).contains(MessageFormat.format(
                 Main.WRONG_REQUEST_TOPIC, version,
                 Main.buildTopicURL(Constants.TOPIC_POST_ONE_KITCHEN_RESTAURANT_TEMPLATE),
                 Main.buildTopicURL(Constants.TOPIC_POST_RESTAURANT_TEMPLATE)));
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_POST_ONE_KITCHEN_RESTAURANT_TEMPLATE.getId());
     }
 
     @Test
@@ -823,11 +889,12 @@ public class MainTest extends TestBase {
                 Constants.QUERY_GET_LAST_ONE_KITCHEN_RESTAURANT_TEMPLATE_REPLY, request);
         String[] args = { Options.COMMAND_ONE_KITCHEN_RESTAURANT_TEMPLATE };
         Main.main(args);
-        System.out.println(WorkRequestHandler.getLastStatusPost().raw);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Fail");
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains(
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Fail");
+        assertThat(statusPost.raw).contains(
                 MessageFormat.format(RestaurantTemplateParser.MISSING_FORMULA_VALUE, "51"));
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_POST_ONE_KITCHEN_RESTAURANT_TEMPLATE.getId());
     }
 
     @Test
@@ -858,9 +925,10 @@ public class MainTest extends TestBase {
                 Constants.QUERY_GET_LAST_ONE_KITCHEN_RESTAURANT_TEMPLATE_REPLY, request);
         String[] args = { Options.COMMAND_ONE_KITCHEN_RESTAURANT_TEMPLATE };
         Main.main(args);
-        System.out.println(WorkRequestHandler.getLastStatusPost().raw);
-        assertThat(WorkRequestHandler.getLastStatusPost()).isNotNull();
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Succeeded");
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Succeeded");
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_POST_ONE_KITCHEN_RESTAURANT_TEMPLATE.getId());
     }
 
     @Test
@@ -886,12 +954,14 @@ public class MainTest extends TestBase {
                 Constants.QUERY_GET_LAST_RESTAURANT_TEMPLATE_REPLY, request);
         String[] args = { Options.COMMAND_RESTAURANT_TEMPLATE };
         Main.main(args);
-        System.out.println(WorkRequestHandler.getLastStatusPost().raw);
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Fail");
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains(MessageFormat.format(
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Fail");
+        assertThat(statusPost.raw).contains(MessageFormat.format(
                 Main.WRONG_REQUEST_TOPIC, version,
                 Main.buildTopicURL(Constants.TOPIC_POST_RESTAURANT_TEMPLATE),
                 Main.buildTopicURL(Constants.TOPIC_POST_ONE_KITCHEN_RESTAURANT_TEMPLATE)));
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_POST_RESTAURANT_TEMPLATE.getId());
     }
 
     @Test
@@ -912,8 +982,10 @@ public class MainTest extends TestBase {
                 Constants.QUERY_GET_LAST_RESTAURANT_TEMPLATE_REPLY, request);
         String[] args = { Options.COMMAND_RESTAURANT_TEMPLATE };
         Main.main(args);
-        System.out.println(WorkRequestHandler.getLastStatusPost().raw);
-        assertThat(WorkRequestHandler.getLastStatusPost().raw).contains("Status: Succeeded");
+        Post statusPost = WorkRequestHandler.getLastStatusPost();
+        assertThat(statusPost).isNotNull();
+        assertThat(statusPost.raw).contains("Status: Succeeded");
+        assertThat(statusPost.topic_id).isEqualTo(Constants.TOPIC_POST_RESTAURANT_TEMPLATE.getId());
     }
 
     private String findFile(final String prefix, final String suffix) {

--- a/src/test/java/org/helpberkeley/memberdata/TestBase.java
+++ b/src/test/java/org/helpberkeley/memberdata/TestBase.java
@@ -118,7 +118,6 @@ public class TestBase {
             Options.COMMAND_CUSTOMER_CARE_POST,
             Options.COMMAND_FRREG,
             Options.COMMAND_WORK_REQUESTS,
-            Options.COMMAND_TEST_REQUEST,
             Options.COMMAND_ONE_KITCHEN_WORKFLOW,
     };
 
@@ -134,6 +133,7 @@ public class TestBase {
     static final String TEST_SHORT_URL = Constants.UPLOAD_URI_PREFIX + "ab34dezzAndSomethingY.csv";
 
     static final String REQUEST_TEMPLATE = "request-template.json";
+    static final String REQUEST_TEMPLATE_EXTRA = "request-template-extra.json";
 
     protected static void cleanupGeneratedFiles() throws IOException {
         Files.list(Paths.get("."))

--- a/src/test/java/org/helpberkeley/memberdata/v200/WorkflowHBParserTest.java
+++ b/src/test/java/org/helpberkeley/memberdata/v200/WorkflowHBParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022. helpberkeley.org
+ * Copyright (c) 2021-2024. helpberkeley.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,9 +25,6 @@ package org.helpberkeley.memberdata.v200;
 import org.helpberkeley.memberdata.*;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/org/helpberkeley/memberdata/v300/ControlBlockBuilder.java
+++ b/src/test/java/org/helpberkeley/memberdata/v300/ControlBlockBuilder.java
@@ -54,7 +54,7 @@ public class ControlBlockBuilder {
     private List<String> altMealOptions = DEFAULT_ALT_MEAL_OPTIONS_LIST;
     private List<String> altGroceryOptions = DEFAULT_ALT_GROCERY_OPTIONS_LIST;
     private List<String> messageFormat = DEFAULT_MESSAGE_FORMAT_LIST;
-    private List<String> backupDrivers = new ArrayList<>();
+    private final List<String> backupDrivers = new ArrayList<>();
     private List<String> pickupManagers = DEFAULT_PICKUP_MANAGERS_LIST;
 
     @Override

--- a/src/test/resources/last-replies-all-requests.json
+++ b/src/test/resources/last-replies-all-requests.json
@@ -17,7 +17,8 @@
     "topic_id",
     "post_number",
     "deleted_at",
-    "raw"
+    "raw",
+    "title"
   ],
   "default_limit": 1000,
   "rows": [
@@ -25,49 +26,57 @@
       2504,
       1810,
       null,
-      "2020/12/25\n[routed deliveries|attachement](upload://routed-deliveries-v200.csv)\n"
+      "2020/12/25\n[routed deliveries|attachement](upload://routed-deliveries-v200.csv)\n",
+      "Request driver messages"
     ],
     [
       2844,
       911,
       null,
-      "2020/12/25\n[unrouted deliveries|attachement](upload://unrouted-deliveries.csv)\n"
+      "2020/12/25\n[unrouted deliveries|attachement](upload://unrouted-deliveries.csv)\n",
+      "Request driver routes"
     ],
     [
       4878,
       151,
       null,
-      "2020/12/16\n\n[HelpBerkeleyDeliveries - 7_3.csv|attachment](upload://routed-deliveries-turkey.csv)"
+      "2020/12/16\n\n[HelpBerkeleyDeliveries - 7_3.csv|attachment](upload://routed-deliveries-turkey.csv)",
+      "Request OneKitchen driver messages"
     ],
     [
       1860,
       30,
       null,
-      "2020/09/28\n\n[HelpBerkeleyDeliveries - TemplateV2-0-0.csv|attachment](upload://restaurant-template-v200.csv) (5.6 KB)"
+      "2020/09/28\n\n[HelpBerkeleyDeliveries - TemplateV2-0-0.csv|attachment](upload://restaurant-template-v200.csv) (5.6 KB)",
+      "Post restaurant template for driver messages"
     ],
     [
       6548,
       2,
       null,
-      "2020/09/28\n\n[HelpBerkeleyDeliveries - TemplateV2-0-0.csv|attachment](upload://restaurant-template-v300.csv) (5.6 KB)"
+      "2020/09/28\n\n[HelpBerkeleyDeliveries - TemplateV2-0-0.csv|attachment](upload://restaurant-template-v300.csv) (5.6 KB)",
+      "Post restaurant template for OneKitchen driver messages"
     ],
     [
       859,
       460,
       null,
-      "2020/12/31\n\n[HelpBerkeleyDeliveries - 12_31.csv|attachment](upload://routed-deliveries-v200.csv) (8.2 KB)"
+      "2020/12/31\n\n[HelpBerkeleyDeliveries - 12_31.csv|attachment](upload://routed-deliveries-v200.csv) (8.2 KB)",
+      "Post completed daily orders"
     ],
     [
       8506,
       460,
       null,
-      "2022/01/15\nOneKitchen\n"
+      "2022/01/15\nOneKitchen\n",
+      "Request Workflow"
     ],
     [
       6889,
       460,
       null,
-      "2020/12/31\n\n[HelpBerkeleyDeliveries - 12_31.csv|attachment](upload://routed-deliveries-v300.csv) (8.2 KB)"
+      "2020/12/31\n\n[HelpBerkeleyDeliveries - 12_31.csv|attachment](upload://routed-deliveries-v300.csv) (8.2 KB)",
+      "Post completed OneKitchen orders"
     ]
   ]
 }

--- a/src/test/resources/last-replies-bad-request.json
+++ b/src/test/resources/last-replies-bad-request.json
@@ -17,17 +17,18 @@
     "topic_id",
     "post_number",
     "deleted_at",
-    "raw"
+    "raw",
+    "title"
   ],
   "default_limit": 1000,
   "rows": [
-    [ 2844, 911, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 2844\n" ],
-    [ 2504, 1810, null, "2021/03/04 21:09:17\n\nStatus: Failed\nSome error message\n" ],
-    [ 4878, 151, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something\n" ],
-    [ 1860, 30, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 1860\n" ],
-    [ 6548, 30, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 6548\n" ],
-    [ 859, 460, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 859\n" ],
-    [ 8506, 460, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 8506\n" ],
-    [ 6889, 460, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 6889\n" ]
+    [ 2844, 1810, null, "2021/03/04 21:09:17\n\nStatus: Succeeded\nSome something from 2844\n", "Request driver routes" ],
+    [ 2504, 1810, null, "2021/03/04 21:09:17\n\nStatus: Failed\nSome error message\n", "Request driver messages" ],
+    [ 4878, 151, null,"2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something\n", "Request OneKitchen driver messages" ],
+    [ 1860, 30, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 1860\n", "Post restaurant template for driver messages" ],
+    [ 6548, 30, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 6548\n", "Post restaurant template for OneKitchen driver messages" ],
+    [ 859, 460, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 859\n", "Post completed daily orders" ],
+    [ 8506, 151, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something\n", "Request Workflow" ],
+    [ 6889, 460, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 6889\n", "Post completed OneKitchen orders" ]
   ]
 }

--- a/src/test/resources/last-replies-daily-workflow-request.json
+++ b/src/test/resources/last-replies-daily-workflow-request.json
@@ -17,22 +17,24 @@
     "topic_id",
     "post_number",
     "deleted_at",
-    "raw"
+    "raw",
+    "title"
   ],
   "default_limit": 1000,
   "rows": [
-    [ 2844, 1810, null, "2021/03/04 21:09:17\n\nStatus: Succeeded\nSome something from 2844\n" ],
-    [ 2504, 1810, null, "2021/03/04 21:09:17\n\nStatus: Succeeded\nSome something from 2504\n" ],
-    [ 4878, 151, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something\n" ],
+    [ 2844, 1810, null, "2021/03/04 21:09:17\n\nStatus: Succeeded\nSome something from 2844\n", "Request driver routes" ],
+    [ 2504, 1810, null, "2021/03/04 21:09:17\n\nStatus: Succeeded\nSome something from 2504\n", "Request driver messages" ],
+    [ 4878, 151, null,"2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something\n", "Request OneKitchen driver messages" ],
     [
       8506,
       460,
       null,
-      "2022/01/15\nDaily\n"
+      "2022/01/15\nDaily\n",
+      "Request Workflow"
     ],
-    [ 1860, 30, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 1860\n" ],
-    [ 859, 460, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 859\n" ],
-    [ 6548, 30, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 6548\n" ],
-    [ 6889, 460, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 6889\n" ]
+    [ 1860, 30, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 1860\n", "Post restaurant template for driver messages" ],
+    [ 859, 460, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 859\n", "Post completed daily orders" ],
+    [ 6548, 30, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 6548\n", "Post restaurant template for OneKitchen driver messages" ],
+    [ 6889, 460, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 6889\n", "Post completed OneKitchen orders" ]
   ]
 }

--- a/src/test/resources/last-replies-no-requests.json
+++ b/src/test/resources/last-replies-no-requests.json
@@ -17,17 +17,19 @@
     "topic_id",
     "post_number",
     "deleted_at",
-    "raw"
+    "raw",
+    "title"
   ],
   "default_limit": 1000,
   "rows": [
-    [ 2844, 1810, null, "2021/03/04 21:09:17\n\nStatus: Succeeded\nSome something from 2844\n" ],
-    [ 2504, 1810, null, "2021/03/04 21:09:17\n\nStatus: Succeeded\nSome something from 2504\n" ],
-    [ 4878, 151, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something\n" ],
-    [ 8506, 151, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something\n" ],
-    [ 1860, 30, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 1860\n" ],
-    [ 859, 460, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 859\n" ],
-    [ 6548, 30, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 6548\n" ],
-    [ 6889, 460, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 6889\n" ]
+    [ 2844, 1810, null, "2021/03/04 21:09:17\n\nStatus: Succeeded\nSome something from 2844\n", "Request driver routes" ],
+    [ 2504, 1810, null, "2021/03/04 21:09:17\n\nStatus: Succeeded\nSome something from 2504\n", "Request driver messages" ],
+    [ 4878, 151, null,"2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something\n", "Request OneKitchen driver messages" ],
+    [ 8506, 151, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something\n", "Request Workflow" ],
+    [ 1860, 30, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 1860\n", "Post restaurant template for driver messages" ],
+    [ 859, 460, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 859\n", "Post completed daily orders" ],
+    [ 6548, 30, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 6548\n", "Post restaurant template for OneKitchen driver messages" ],
+    [ 6889, 460, null, "2021/02/28 16:42:27\n\nStatus: Succeeded\nFile: something from 6889\n", "Post completed OneKitchen orders" ]
   ]
 }
+

--- a/src/test/resources/request-template-extra.json
+++ b/src/test/resources/request-template-extra.json
@@ -1,0 +1,20 @@
+{
+  "success": true,
+  "errors": [],
+  "duration": 0.4,
+  "result_count": 1,
+  "params": {},
+  "columns": [
+    "post_number",
+    "deleted_at",
+    "raw"
+  ],
+  "default_limit": 1000,
+  "rows": [
+    [
+      2,
+      null,
+      "REPLACE_DATE\nREPLACE_EXTRA\n[REPLACE_FILENAME|attachment](upload://REPLACE_FILENAME)"
+    ]
+  ]
+}


### PR DESCRIPTION
This commit updates OneKitchen and Driver message generation status messages to show the correct destination topic for the generated messages, whether or not the Test topic directive is being used.


Issue: Update status message for OneKitchen and Restaurant Driver Messages #13

Created a new version of the get last reply from request topics query to include on the helpberkeley site, which adds a topic name column. Added support for this in the request handling logic.

Added/renamed WorkRequest classes fields to disambiguate request (source) topic, vs. destination topic for non-status message output when test topic is being used.

Updated the end to end (MainTest) tests to all check that status messages are being posted to the appropriate topic.

Misc. cleanup.